### PR TITLE
Feature/fix 137 cross chain

### DIFF
--- a/config.prod.json
+++ b/config.prod.json
@@ -6,20 +6,10 @@
       "oracle": "0x36dA71ccAd7A67053f0a4d9D5f55b725C9A25A3E",
       "providerUrl": ""
     },
-    "5": {
-      "forwarder": "0xc684E8645c8414812f22918146d72d1071E722AE",
-      "oracle": "0x36dA71ccAd7A67053f0a4d9D5f55b725C9A25A3E",
-      "providerUrl": ""
-    },
     "137": {
       "forwarder": "0xc684E8645c8414812f22918146d72d1071E722AE",
       "oracle": "0x36dA71ccAd7A67053f0a4d9D5f55b725C9A25A3E",
-      "providerUrl": "https://rpc-mainnet.maticvigil.com"
-    },
-    "80001": {
-      "forwarder": "0xc684E8645c8414812f22918146d72d1071E722AE",
-      "oracle": "0x36dA71ccAd7A67053f0a4d9D5f55b725C9A25A3E",
-      "providerUrl": "https://rpc-mumbai.maticvigil.com"
+      "providerUrl": ""
     }
   }
 }

--- a/src/dapp.ts
+++ b/src/dapp.ts
@@ -92,7 +92,7 @@ const start = async () => {
     if (allForwardRequestsAccepted) {
       console.log("All forward requests accepted by Forwarder API");
     } else {
-      console.error("At least one forward request rejected by Forwarder API");
+      console.error("At least one forward request did not succeed");
     }
   }
   return encodedValue;

--- a/src/forward/forwardSender.ts
+++ b/src/forward/forwardSender.ts
@@ -28,7 +28,7 @@ export async function postForwardRequest(
     await response
       .json()
       .then((body) => body.message)
-      .then(console.log)
+      .catch((e) => undefined)
   );
   return false;
 }

--- a/tests/forward/forwardEnvironment.test.ts
+++ b/tests/forward/forwardEnvironment.test.ts
@@ -5,8 +5,8 @@ import {
 
 describe("Environment", () => {
   test("should get environment", async () => {
-    expect(getForwarderApiUrl()).toContain("http");
-    expect(getOnChainConfig(5)).toBeDefined();
-    expect(getOnChainConfig(80001)).toBeDefined();
+    expect(getForwarderApiUrl()).toContain("https");
+    expect(getOnChainConfig(1)).toBeDefined();
+    expect(getOnChainConfig(137)).toBeDefined();
   });
 });

--- a/tests/forward/forwardHandler.test.ts
+++ b/tests/forward/forwardHandler.test.ts
@@ -18,7 +18,7 @@ const postMultiForwardRequestMock = postForwardRequest as jest.MockedFunction<
 
 const TASK_ID =
   "0x0000000000000000000000000000000000000000000000000000000000000abc";
-const CHAIN_ID = 5;
+const CHAIN_ID = 137;
 const ORACLE_ID = "0x1";
 const VALUE = "0x2";
 const wallet = new Wallet(


### PR DESCRIPTION
There are a lot of things to clean but the sole purpose of this PR is to fix cross-chain updates to polygon.
This will require building and deploying a new image of the dapp, owners of API key datasets will need to allow the new app address in their datasetorders. 

changed:
- use ethers default endpoint for chain 137 (previously used decommissioned endpoint https://rpc-mainnet.maticvigil.com)
- remove discontinued chains 5 and 80001
- fix bad error handling leading to executing code with bad data